### PR TITLE
Add openzepplin erc20 implementation

### DIFF
--- a/contracts/src/starknet/staticAToken.cairo
+++ b/contracts/src/starknet/staticAToken.cairo
@@ -1,0 +1,5 @@
+%lang starknet
+
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+)

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "hardhat --network localhost test",
-    "compile": "hardhat starknet-compile",
+    "compile": "hardhat starknet-compile --cairo-path 'node_modules/@joriksch/oz-cairo'",
     "compile:starkgate": "hardhat starknet-compile --cairo-path 'starkgate-contracts/src' starkgate-contracts",
-    "compile:fossil": "hardhat starknet-compile node_modules/@joriksch/fossil/contracts --cairo-path node_modules/@joriksch/fossil/contracts"
+    "compile:fossil": "hardhat starknet-compile node_modules/@joriksch/fossil/contracts --cairo-path node_modules/@joriksch/fossil/contracts",
+    "compile:openzeppelin": "yarn hardhat starknet-compile node_modules/@joriksch/oz-cairo --cairo-path node_modules/@joriksch/oz-cairo/"
   },
   "author": "AAVE",
   "license": "Apache-2.0",
@@ -25,6 +26,7 @@
   },
   "dependencies": {
     "@joriksch/fossil": "^0.0.1",
+    "@joriksch/oz-cairo": "^1.0.0",
     "@joriksch/sg-contracts": "^0.0.2",
     "@toruslabs/starkware-crypto": "^1.0.0",
     "hardhat": "2.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,6 +428,11 @@
   resolved "https://registry.yarnpkg.com/@joriksch/fossil/-/fossil-0.0.1.tgz#1d95dfdb739f39eeb362f55ea742dbf3336a6d6f"
   integrity sha512-MO3ScoGHllFH4+BKrWHkmZBkONc+2/7J1qiHHBOVcquwcs08aCNLHhvzrpgY2wh+9oh1jVoUwS3V+zN3Nmb8Ug==
 
+"@joriksch/oz-cairo@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@joriksch/oz-cairo/-/oz-cairo-1.0.0.tgz#eb840636444edd49e61e15304edac4be30a5cac4"
+  integrity sha512-Xu5/jHAyzItUeylW1tyl+0cp+VozsDIm1GnIZDveVJIt9HLJ/7cmf04Uh/KPwl28qjf0TooyL3otLoimeT4C1g==
+
 "@joriksch/sg-contracts@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@joriksch/sg-contracts/-/sg-contracts-0.0.2.tgz#65cdd9560b0349cdd7c0e86af12fb4e5cfa34f2d"


### PR DESCRIPTION
Currently very few of the libraries we're depending on are distributed on npm. I've published my own with the expectation that we'll replace them with the upstream when they're made available.