### PR TITLE
Add ray and wad tests

### DIFF
--- a/contracts/src/starknet/rewaave/math/wad_ray_math.cairo
+++ b/contracts/src/starknet/rewaave/math/wad_ray_math.cairo
@@ -9,7 +9,7 @@ const HALF_WAD = WAD / 2
 const RAY = 10 ** 27
 const HALF_RAY = RAY / 2
 
-const UINT128_MAX = 2 ** 129 - 1
+const UINT128_MAX = 2 ** 128 - 1
 
 # WAD_RAY_RATIO = 1 * 10 ^ 9
 const WAD_RAY_RATIO = 10 ** 9
@@ -82,7 +82,7 @@ func wad_div{range_check_ptr}(a : Uint256, b : Uint256) -> (res : Uint256):
     let (UINT256_MAX) = uint256_max()
     let (WAD_UINT) = wad()
 
-    with_attr error_message("WAD multiplication overflow"):
+    with_attr error_message("WAD div overflow"):
         let (bound) = uint256_sub(UINT256_MAX, halfB)
         let (quo, _) = uint256_unsigned_div_rem(bound, WAD_UINT)
         let (le) = uint256_le(a, quo)
@@ -108,7 +108,7 @@ func ray_mul{range_check_ptr}(a : Uint256, b : Uint256) -> (res : Uint256):
     let (HALF_RAY_UINT) = half_ray()
     let (RAY_UINT) = ray()
 
-    with_attr error_message("RAY multiplication overflow"):
+    with_attr error_message("RAY div overflow"):
         let (bound) = uint256_sub(UINT256_MAX, HALF_RAY_UINT)
         let (quotient, rem) = uint256_unsigned_div_rem(bound, b)
         let (le) = uint256_le(a, quotient)

--- a/contracts/src/starknet/rewaave/tokens/claimable.cairo
+++ b/contracts/src/starknet/rewaave/tokens/claimable.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.uint256 import (
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.math_cmp import is_le
 
-from rewaave.math.wad_ray_math import wad_to_ray, ray_mul_no_rounding, ray_to_wad_no_rounding
+from rewaave.math.wad_ray_math import ray_mul_no_rounding, ray_to_wad_no_rounding
 from openzeppelin.token.erc20.library import ERC20_totalSupply, ERC20_balanceOf, ERC20_mint
 from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner, Ownable_get_owner
 

--- a/contracts/test/WadRayTests.cairo
+++ b/contracts/test/WadRayTests.cairo
@@ -1,0 +1,278 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256, uint256_add, uint256_sub
+
+from rewaave.math.wad_ray_math import (
+    wad_mul, wad_div, ray_mul, ray_div, ray_to_wad, wad_to_ray, ray_mul_no_rounding,
+    ray_to_wad_no_rounding, ray, wad, uint256_max, half_wad, half_ray)
+
+@view
+func test_wad_mul{range_check_ptr}():
+    alloc_locals
+
+    let (wad_) = wad()
+
+    # zero test
+
+    let (res) = wad_mul(Uint256(0, 10000), Uint256(0, 0))
+    assert res = Uint256(0, 0)
+
+    let (res) = wad_mul(Uint256(0, 0), Uint256(0, 10000))
+    assert res = Uint256(0, 0)
+
+    # 1 test
+
+    let (res) = wad_mul(Uint256(0, 10000), wad_)
+    assert res = Uint256(0, 10000)
+
+    let (res) = wad_mul(wad_, Uint256(0, 10000))
+    assert res = Uint256(0, 10000)
+
+    # random muls
+
+    let (wad2, _) = uint256_add(wad_, wad_)
+    let (wad4, _) = uint256_add(wad2, wad2)
+    let (res) = wad_mul(wad2, wad2)
+
+    assert res = wad4
+
+    # underflow test
+
+    let (res) = wad_mul(Uint256(1000, 0), Uint256(1, 0))
+    assert res = Uint256(0, 0)
+
+    let (res) = wad_mul(Uint256(1, 0), Uint256(10000, 0))
+    assert res = Uint256(0, 0)
+
+    return ()
+end
+
+@view
+func test_wad_mul_overflow{range_check_ptr}():
+    alloc_locals
+    let (uint256_max_) = uint256_max()
+    let (res) = wad_mul(uint256_max_, uint256_max_)  # expected to revert
+    return ()
+end
+
+@view
+func test_ray_mul{range_check_ptr}():
+    alloc_locals
+
+    let (ray_) = ray()
+
+    # zero test
+
+    let (res) = ray_mul(Uint256(0, 10000), Uint256(0, 0))
+    assert res = Uint256(0, 0)
+
+    let (res) = ray_mul(Uint256(0, 0), Uint256(0, 10000))
+    assert res = Uint256(0, 0)
+
+    # 1 test
+
+    let (res) = ray_mul(Uint256(0, 10000), ray_)
+    assert res = Uint256(0, 10000)
+
+    let (res) = ray_mul(ray_, Uint256(0, 10000))
+    assert res = Uint256(0, 10000)
+
+    # random muls
+
+    let (ray2, _) = uint256_add(ray_, ray_)
+    let (ray4, _) = uint256_add(ray2, ray2)
+    let (res) = ray_mul(ray2, ray2)
+
+    assert res = ray4
+
+    # underflow test
+
+    let (res) = ray_mul(Uint256(1000, 0), Uint256(1, 0))
+    assert res = Uint256(0, 0)
+
+    let (res) = ray_mul(Uint256(1, 0), Uint256(10000, 0))
+    assert res = Uint256(0, 0)
+
+    return ()
+end
+
+@view
+func test_ray_mul_overflow{range_check_ptr}():
+    alloc_locals
+    let (uint256_max_) = uint256_max()
+    let (res) = ray_mul(uint256_max_, uint256_max_)  # expected to revert
+    return ()
+end
+
+@view
+func test_wad_div{range_check_ptr}():
+    alloc_locals
+
+    let (wad_) = wad()
+    let (half_wad_) = half_wad()
+
+    # 1 div
+
+    let (res) = wad_div(Uint256(1000, 0), wad_)
+    assert res = Uint256(1000, 0)
+
+    # some other divs
+
+    let (wad2, _) = uint256_add(wad_, wad_)
+    let (res) = wad_div(wad_, wad2)
+    assert res = half_wad_
+
+    # Underflow
+
+    let (res) = wad_div(Uint256(1, 0), Uint256(0, 100000000000000000000))
+    assert res = Uint256(0, 0)
+
+    return ()
+end
+
+@view
+func test_wad_div_zero{range_check_ptr}():
+    wad_div(Uint256(1, 1), Uint256(0, 0))
+    return ()
+end
+
+@view
+func test_wad_div_overflow{range_check_ptr}():
+    let (uint256_max_) = uint256_max()
+    wad_div(uint256_max_, Uint256(1, 0))
+    return ()
+end
+
+@view
+func test_ray_div{range_check_ptr}():
+    alloc_locals
+
+    let (ray_) = ray()
+    let (half_ray_) = half_ray()
+
+    # 1 div
+
+    let (res) = ray_div(Uint256(1000, 0), ray_)
+    assert res = Uint256(1000, 0)
+
+    # some other divs
+
+    let (ray2, _) = uint256_add(ray_, ray_)
+    let (res) = ray_div(ray_, ray2)
+    assert res = half_ray_
+
+    # Underflow
+
+    let (res) = ray_div(Uint256(1, 0), Uint256(0, 100000000000000000000))
+    assert res = Uint256(0, 0)
+
+    return ()
+end
+
+@view
+func test_ray_div_zero{range_check_ptr}():
+    ray_div(Uint256(1, 1), Uint256(0, 0))
+    return ()
+end
+
+@view
+func test_ray_div_overflow{range_check_ptr}():
+    let (uint256_max_) = uint256_max()
+    ray_div(uint256_max_, Uint256(1, 0))
+    return ()
+end
+
+@view
+func test_ray_to_wad{range_check_ptr}():
+    alloc_locals
+    let (ray_) = ray()
+    let (wad_) = wad()
+
+    let (res) = ray_to_wad(ray_)
+    assert res = wad_
+
+
+    return ()
+end
+
+@view
+func test_wad_to_ray{range_check_ptr}():
+    alloc_locals
+    let (ray_) = ray()
+    let (wad_) = wad()
+
+    let (res) = wad_to_ray(wad_)
+    assert res = ray_
+
+    return ()
+end
+
+@view
+func test_ray_mul_no_rounding{range_check_ptr}():
+    alloc_locals
+
+    let (ray_) = ray()
+
+    # zero test
+
+    let (res) = ray_mul_no_rounding(Uint256(0, 10000), Uint256(0, 0))
+    assert res = Uint256(0, 0)
+
+    let (res) = ray_mul_no_rounding(Uint256(0, 0), Uint256(0, 10000))
+    assert res = Uint256(0, 0)
+
+    # 1 test
+
+    let (res) = ray_mul_no_rounding(Uint256(0, 10000), ray_)
+    assert res = Uint256(0, 10000)
+
+    let (res) = ray_mul_no_rounding(ray_, Uint256(0, 10000))
+    assert res = Uint256(0, 10000)
+
+    # random muls
+
+    let (ray2, _) = uint256_add(ray_, ray_)
+    let (ray4, _) = uint256_add(ray2, ray2)
+    let (res) = ray_mul_no_rounding(ray2, ray2)
+
+    assert res = ray4
+
+    # underflow test
+
+    let (res) = ray_mul_no_rounding(Uint256(1000, 0), Uint256(1, 0))
+    assert res = Uint256(0, 0)
+
+    let (res) = ray_mul_no_rounding(Uint256(1, 0), Uint256(10000, 0))
+    assert res = Uint256(0, 0)
+
+    return ()
+end
+
+@view
+func test_ray_mul_no_rounding_overflow{range_check_ptr}():
+    alloc_locals
+    let (uint256_max_) = uint256_max()
+    let (res) = ray_mul_no_rounding(uint256_max_, uint256_max_)  # expected to revert
+    return ()
+end
+
+@view
+func test_ray_to_wad_no_rounding{range_check_ptr}():
+    alloc_locals
+
+    let (ray_) = ray()
+    let (wad_) = wad()
+
+    let (res) = ray_to_wad_no_rounding(ray_)
+    assert res = wad_
+
+    # check rounding
+
+    let (ray_diminished) = uint256_sub(ray_, Uint256(1, 0))
+    let (wad_diminished) = uint256_sub(wad_, Uint256(1, 0))
+
+    let (res) = ray_to_wad_no_rounding(ray_diminished)
+    assert res = wad_diminished
+
+    return ()
+end

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "hardhat --network localhost test",
     "compile": "hardhat starknet-compile --cairo-path 'node_modules/@joriksch/oz-cairo:contracts/src/starknet'",
+    "compile:tests": "hardhat starknet-compile --cairo-path 'node_modules/@joriksch/oz-cairo:contracts/src/starknet' contracts/test",
     "deploy:account": "yarn hardhat starknet-deploy-account --starknet-network devnet --wallet OpenZeppelin",
     "compile:starkgate": "hardhat starknet-compile --cairo-path 'starkgate-contracts/src' starkgate-contracts",
     "compile:fossil": "hardhat starknet-compile node_modules/@joriksch/fossil/contracts --cairo-path node_modules/@joriksch/fossil/contracts",

--- a/test/wad_ray_math.test.ts
+++ b/test/wad_ray_math.test.ts
@@ -1,0 +1,102 @@
+import {expect} from 'chai';
+import {starknet} from 'hardhat';
+import {StarknetContract} from 'hardhat/types';
+import {TIMEOUT} from './constants';
+
+describe('wad_ray_math', function () {
+  this.timeout(TIMEOUT);
+
+  let wadRayTestContract: StarknetContract;
+
+  before(async () => {
+    wadRayTestContract = await (await starknet.getContractFactory('WadRayTests')).deploy();
+  });
+
+  it('multiplies wads', async () => {
+    await wadRayTestContract.call("test_wad_mul");
+  });
+
+  it('reverts on wad multiplication overflows', async () => {
+    try {
+      await wadRayTestContract.call("test_wad_mul_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('divides wads', async () => {
+    await wadRayTestContract.call("test_wad_div");
+  });
+
+  it('reverts on wad divide by zero', async () => {
+    try {
+      await wadRayTestContract.call("test_wad_div_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('reverts on wad divide overflows', async () => {
+    try {
+      await wadRayTestContract.call("test_wad_div_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('multiplies rays', async () => {
+    await wadRayTestContract.call("test_ray_mul");
+  });
+
+  it('reverts on ray multiplication overflows', async () => {
+    try {
+      await wadRayTestContract.call("test_ray_mul_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('divides rays', async () => {
+    await wadRayTestContract.call("test_ray_div");
+  });
+
+  it('reverts on ray divide by zero', async () => {
+    try {
+      await wadRayTestContract.call("test_ray_div_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('reverts on ray divide overflows', async () => {
+    try {
+      await wadRayTestContract.call("test_ray_div_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('multiplies_no_rounding rays', async () => {
+    await wadRayTestContract.call("test_ray_mul_no_rounding");
+  });
+
+  it('reverts on ray multiplication_no_rounding overflows', async () => {
+    try {
+      await wadRayTestContract.call("test_ray_mul_no_rounding_overflow");
+      expect.fail("Overflow should revert")
+    } catch {
+    }
+  });
+
+  it('converts rays to wads', async () => {
+    await wadRayTestContract.call("test_ray_to_wad");
+  });
+
+  it('converts wads to rays', async () => {
+    await wadRayTestContract.call("test_wad_to_ray");
+  });
+
+  it('no_rounding converts rays to wads', async () => {
+    await wadRayTestContract.call("test_ray_to_wad_no_rounding");
+  });
+})


### PR DESCRIPTION
The only two functions we're using are `ray_mul_no_rounding` and `ray_to_wad_no_rounding`. You might notice there are two or three methods in the source related to 'no rounding' divisions which I haven't written tests for. This is intentional and I might take out their implementations later.