### PR TITLE
Peckshield & Certora Audit

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,6 +26,7 @@ jobs:
             "proxy.test.ts",
             "bridge.test.ts",
             "wad_ray_math.test.ts",
+            "deposit_cancellation.test.ts",
           ]
         python-version: ["3.7"] # Cairo was tested with this version
         node-version: ["16"]

--- a/README.md
+++ b/README.md
@@ -4,31 +4,30 @@
 [![Check](https://github.com/aave-starknet-project/aave-starknet-bridge/actions/workflows/code-check.yml/badge.svg)](https://github.com/aave-starknet-project/aave-starknet-bridge/actions/workflows/code-check.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/aave-starknet-project/aave-starknet-bridge/blob/main/LICENSE.md)
 
-:warning: This codebase is still in an experimental phase, has not been
+:warning: This codebase is still in an experimental phase, is currently being
 audited, might contain bugs and should not be used in production.
 
 ## Table of contents
 
-- [Introduction](#introduction)
-- [Architecture](#architecture)
-- [Contracts](#contracts)
-  - [Overview](#overview)
-  - [More about static_a_token on L2](#more-about-static_a_token-on-l2)
-  - [Proxies](#proxies)
-  - [Governance](#governance)
-- [How does it work?](#how-does-it-work)
-  - [Bridging aTokens from L1 to L2](#bridging-atokens-from-l1-to-l2)
-    - [Approve bridge tokens](#approve-bridge-tokens)
-    - [Transfer from L1 to L2](#transfer-l1-to-l2)
-    - [Transfer from L2 to L1](#transfer-l2-to-l1)
-  - [Synchronisation of rewards on L1 and L2](#synchronisation-of-rewards-on-l1-and-l2)
-  - [Claiming rewards on L2](#claiming-rewards-on-l2)
-  - [Bridging rewards from L2 to L1](#bridging-rewards-from-l2-to-l1)
-- [Installation](#installation)
-  - [Environment](#environment)
-  - [Build the cairo files](#build-cairo-files)
-  - [Start testnets](#start-testnets)
-  - [Run tests](#run-tests)
+  - [Introduction](#introduction)
+  - [Architecture](#architecture)
+  - [Contracts](#contracts)
+    - [Overview](#overview)
+    - [More about static_a_token on L2](#more-about-static_a_token-on-l2)
+    - [Proxies](#proxies)
+    - [Governance](#governance)
+  - [How does it work?](#how-does-it-work)
+    - [Bridging aTokens from L1 to L2](#bridging-atokens-from-l1-to-l2)
+    - [Synchronisation of rewards on L1 and L2](#synchronisation-of-rewards-on-l1-and-l2)
+    - [Claiming rewards on L2](#claiming-rewards-on-l2)
+    - [Bridging rewards from L2 to L1](#bridging-rewards-from-l2-to-l1)
+    - [ATokens deposit cancellation](#atokens-deposit-cancellation)
+  - [Installation](#installation)
+    - [Environment](#environment)
+    - [Build Cairo files](#build-cairo-files)
+    - [Start testnets](#start-testnets)
+    - [Run tests](#run-tests)
+    - [Deployment](#deployment)
 
 ## Introduction
 
@@ -171,6 +170,15 @@ Calling `bridge_rewards` on L2 token bridge results in:
 - The L1 bridge receives the bridging message and claims the rewards amount to
   self by calling `claimRewards` on the `IncentivesController` contract.
 - The rewards are then transferred to the L1 recipient.
+
+### ATokens deposit cancellation
+If L1 -> L2 message consumption is unsuccessful, the user would lose custody over his aTokens forever.
+
+That's why we have added support for the L1->L2 message cancellation on our L1 bridge contract, where users can cancel deposits of their aTokens by following the steps below:
+
+1. The user calls `startDepositCancellation` on L1 bridge by providing the `message payload` and `nonce` of the `deposit` message.
+
+2. After the `messageCancellationDelay` period has passed (defined on [StarknetMessaging](https://github.com/starkware-libs/starkgate-contracts/blob/c08863a1f08226c09f1d0748124192e848d73db9/src/starkware/starknet/solidity/StarknetMessaging.sol) contract), the user can finalize the aTokens deposit cancellation by calling `cancelDeposit` on L1 bridge.
 
 ## Installation
 

--- a/contracts/l1/Bridge.sol
+++ b/contracts/l1/Bridge.sol
@@ -69,11 +69,7 @@ contract Bridge is IBridge, VersionedInitializable {
         address incentivesController,
         address[] calldata l1Tokens,
         uint256[] calldata l2Tokens
-    ) external virtual initializer {
-        require(
-            Cairo.isValidL2Address(l2Bridge),
-            Errors.B_L2_ADDRESS_OUT_OF_RANGE
-        );
+    ) external virtual onlyValidL2Address(l2Bridge) initializer {
         require(
             address(incentivesController) != address(0),
             Errors.B_INVALID_INCENTIVES_CONTROLLER_ADDRESS

--- a/contracts/l1/interfaces/IBridge.sol
+++ b/contracts/l1/interfaces/IBridge.sol
@@ -9,6 +9,7 @@ interface IBridge {
         uint256 l2TokenAddress;
         IERC20 underlyingAsset;
         ILendingPool lendingPool;
+        uint256 ceiling;
     }
 
     event Deposit(

--- a/contracts/l1/interfaces/IBridge.sol
+++ b/contracts/l1/interfaces/IBridge.sol
@@ -33,6 +33,22 @@ interface IBridge {
     event ApprovedBridge(address l1Token, uint256 l2Token);
     event L2StateUpdated(address indexed l1Token, uint256 rewardsIndex);
 
+    event StartedDepositCancellation(
+        uint256 indexed l2Recipient,
+        uint256 rewardsIndex,
+        uint256 blockNumber,
+        uint256 amount,
+        uint256 nonce
+    );
+    event CancelledDeposit(
+        uint256 indexed l2Recipient,
+        address l1Recipient,
+        uint256 rewardsIndex,
+        uint256 blockNumber,
+        uint256 amount,
+        uint256 nonce
+    );
+
     /**
      * @notice allows deposits of aTokens or their underlying assets on L2
      * @param l1AToken aToken address

--- a/contracts/l1/interfaces/IBridge.sol
+++ b/contracts/l1/interfaces/IBridge.sol
@@ -70,7 +70,7 @@ interface IBridge {
      * @notice allows withdraw of aTokens or their underlying assets from L2
      * @param l1AToken aToken address
      * @param l2sender sender address
-     * @param recipient l1 recipient
+     * @param recipient on l1
      * @param staticAmount amount to be withdraw
      * @param toUnderlyingAsset if set to true will withdraw underlying asset tokens from pool and transfer them to recipient
      **/
@@ -80,7 +80,7 @@ interface IBridge {
         address recipient,
         uint256 staticAmount,
         uint256 l2RewardsIndex,
-        bool toUnderlyingAsset
+        uint256 toUnderlyingAsset
     ) external;
 
     /**

--- a/contracts/l1/libraries/helpers/Errors.sol
+++ b/contracts/l1/libraries/helpers/Errors.sol
@@ -114,6 +114,7 @@ library Errors {
     string public constant B_TOKEN_ALREADY_APPROVED = "86";
     string public constant B_INVALID_ADDRESS = "87";
     string public constant B_NOT_ENOUGH_REWARDS = "88";
+    string public constant B_ABOVE_CEILING = "89";
     enum CollateralManagerErrors {
         NO_ERROR,
         NO_COLLATERAL_AVAILABLE,

--- a/test/deposit_cancellation.test.ts
+++ b/test/deposit_cancellation.test.ts
@@ -1,0 +1,329 @@
+import {
+  A_DAI,
+  STKAAVE_WHALE,
+  INCENTIVES_CONTROLLER,
+  LENDING_POOL,
+  DAI_WHALE,
+  EMISSION_MANAGER,
+} from "../constants/addresses";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import chai, { expect } from "chai";
+import { Contract, ContractFactory, providers, BigNumber } from "ethers";
+import hre, { starknet, network, ethers } from "hardhat";
+import {
+  StarknetContractFactory,
+  StarknetContract,
+  HardhatUserConfig,
+  Account,
+  StringMap,
+} from "hardhat/types";
+import { solidity } from "ethereum-waffle";
+import config from "../hardhat.config";
+
+import { TIMEOUT } from "./constants";
+
+chai.use(solidity);
+
+const MAX_UINT256 = hre.ethers.constants.MaxInt256;
+
+// Amount of dai and usdc to transfer to the user. Issued twice for aDai and aUsdc
+const DAI_UNIT = 1000n * BigInt(10 ** 18);
+const daiAmount = 300n * DAI_UNIT;
+
+describe("AToken deposit cancellation", async function () {
+  this.timeout(TIMEOUT);
+
+  const networkUrl =
+    (config as HardhatUserConfig).networks?.l1_testnet?.url ||
+    "http://localhost:8545";
+
+  // users
+  let l1user: SignerWithAddress;
+  let l1ProxyAdmin: SignerWithAddress;
+  let l2owner: Account;
+  let l2user: Account;
+  let signer: SignerWithAddress;
+  let daiWhale: providers.JsonRpcSigner;
+  let emissionManager: providers.JsonRpcSigner;
+
+  // misk
+  let provider: any;
+  let txDai: any;
+
+  // L2
+  //// factories
+  let l2TokenFactory: StarknetContractFactory;
+  let l2ProxyFactory: StarknetContractFactory;
+  let l2BridgeFactory: StarknetContractFactory;
+
+  //// tokens
+  let l2StaticADaiImpl: StarknetContract;
+  let l2StaticADaiProxy: StarknetContract;
+  let l2StaticADai: StarknetContract;
+
+  let l2rewAAVEImpl: StarknetContract;
+  let l2rewAAVEProxy: StarknetContract;
+  let l2rewAAVE: StarknetContract;
+
+  //// token bridge
+  let l2BridgeImpl: StarknetContract;
+  let l2BridgeProxy: StarknetContract;
+  let l2Bridge: StarknetContract;
+
+  // L1
+
+  let mockStarknetMessagingAddress: string;
+
+  //// factories
+  let l1BridgeFactory: ContractFactory;
+  let l1ProxyBridgeFactory: ContractFactory;
+
+  //// token bridge
+  let l1BridgeImpl: Contract;
+  let l1BridgeProxy: Contract;
+  let l1Bridge: Contract;
+
+  //// AAVE contracts
+  let pool: Contract;
+  let incentives: Contract;
+  let aDai: Contract;
+  let dai: Contract;
+
+  before(async function () {
+    // load L1 <--> L2 messaging contract
+
+    mockStarknetMessagingAddress = (
+      await starknet.devnet.loadL1MessagingContract(networkUrl)
+    ).address;
+
+    // L2 deployments
+
+    l2owner = await starknet.deployAccount("OpenZeppelin");
+    l2user = await starknet.deployAccount("OpenZeppelin");
+
+    l2BridgeFactory = await starknet.getContractFactory("bridge");
+    l2BridgeImpl = await l2BridgeFactory.deploy();
+
+    l2ProxyFactory = await starknet.getContractFactory("l2/lib/proxy");
+    l2BridgeProxy = await l2ProxyFactory.deploy({
+      proxy_admin: BigInt(l2user.starknetContract.address),
+    });
+    l2StaticADaiProxy = await l2ProxyFactory.deploy({
+      proxy_admin: BigInt(l2user.starknetContract.address),
+    });
+
+    const rewAaveContractFactory = await starknet.getContractFactory(
+      "l2/tokens/rewAAVE"
+    );
+    l2rewAAVEImpl = await rewAaveContractFactory.deploy();
+    l2rewAAVEProxy = await l2ProxyFactory.deploy({
+      proxy_admin: BigInt(l2owner.starknetContract.address),
+    });
+
+    await l2owner.invoke(l2rewAAVEProxy, "initialize_proxy", {
+      implementation_address: BigInt(l2rewAAVEImpl.address),
+    });
+    l2rewAAVE = rewAaveContractFactory.getContractAt(l2rewAAVEProxy.address);
+
+    await l2owner.invoke(l2rewAAVE, "initialize_rewAAVE", {
+      name: 444,
+      symbol: 444,
+      decimals: 18n,
+      initial_supply: { high: 0n, low: 0n },
+      recipient: BigInt(l2user.starknetContract.address),
+      owner: BigInt(l2BridgeProxy.address),
+    });
+
+    l2TokenFactory = await starknet.getContractFactory("static_a_token");
+    l2StaticADaiImpl = await l2TokenFactory.deploy();
+
+    // L1 deployments
+
+    [signer, l1user, l1ProxyAdmin] = await ethers.getSigners();
+
+    pool = await ethers.getContractAt("LendingPool", LENDING_POOL);
+    incentives = await ethers.getContractAt(
+      "IncentivesControllerMock",
+      INCENTIVES_CONTROLLER
+    );
+
+    aDai = await ethers.getContractAt("AToken", A_DAI);
+    dai = await ethers.getContractAt(
+      "ERC20",
+      await aDai.UNDERLYING_ASSET_ADDRESS()
+    );
+
+    provider = new ethers.providers.JsonRpcProvider(networkUrl);
+    daiWhale = provider.getSigner(DAI_WHALE);
+
+    emissionManager = provider.getSigner(EMISSION_MANAGER);
+
+    await signer.sendTransaction({
+      from: signer.address,
+      to: daiWhale._address,
+      value: ethers.utils.parseEther("1.0"),
+    });
+
+    await signer.sendTransaction({
+      from: signer.address,
+      to: emissionManager._address,
+      value: ethers.utils.parseEther("1.0"),
+    });
+
+    l1BridgeFactory = await ethers.getContractFactory("Bridge", signer);
+    l1BridgeImpl = await l1BridgeFactory.deploy();
+    await l1BridgeImpl.deployed();
+
+    l1ProxyBridgeFactory = await ethers.getContractFactory(
+      "InitializableAdminUpgradeabilityProxy",
+      l1ProxyAdmin
+    );
+    l1BridgeProxy = await l1ProxyBridgeFactory.deploy();
+    await l1BridgeProxy.deployed();
+  });
+
+  it("dai whale converts its Dai to aDai", async () => {
+    // daiWhale deposits dai and gets aDai
+    await dai.connect(daiWhale).transfer(l1user.address, 3n * daiAmount);
+    await dai.connect(l1user).approve(pool.address, MAX_UINT256);
+    await pool
+      .connect(l1user)
+      .deposit(dai.address, 3n * daiAmount, l1user.address, 0);
+  });
+
+  it("set L2 implementation contracts", async () => {
+    {
+      await l2user.invoke(l2StaticADaiProxy, "initialize_proxy", {
+        implementation_address: BigInt(l2StaticADaiImpl.address),
+      });
+      const { implementation } = await l2StaticADaiProxy.call(
+        "get_implementation",
+        {}
+      );
+      expect(implementation).to.equal(BigInt(l2StaticADaiImpl.address));
+      l2StaticADai = l2TokenFactory.getContractAt(l2StaticADaiProxy.address);
+    }
+
+    {
+      await l2user.invoke(l2BridgeProxy, "initialize_proxy", {
+        implementation_address: BigInt(l2BridgeImpl.address),
+      });
+      const { implementation } = await l2BridgeProxy.call(
+        "get_implementation",
+        {}
+      );
+      expect(implementation).to.equal(BigInt(l2BridgeImpl.address));
+      l2Bridge = l2BridgeFactory.getContractAt(l2BridgeProxy.address);
+    }
+  });
+
+  it("initialize L2 static_a_dai", async () => {
+    await l2user.invoke(l2StaticADai, "initialize_static_a_token", {
+      name: 1234n,
+      symbol: 123n,
+      decimals: BigInt(await aDai.decimals()),
+      initial_supply: { high: 0n, low: 0n },
+      recipient: BigInt(l2Bridge.address),
+      owner: BigInt(l2owner.starknetContract.address),
+      l2_bridge: BigInt(l2Bridge.address),
+    });
+  });
+
+  it("set L1 token bridge as implementation contract", async () => {
+    let ABI = [
+      "function initialize(uint256 l2Bridge, address messagingContract, address incentivesController, address[] calldata l1Tokens, uint256[] calldata l2Tokens) ",
+    ];
+    let iface = new ethers.utils.Interface(ABI);
+
+    let encodedInitializedParams = iface.encodeFunctionData("initialize", [
+      l2BridgeProxy.address,
+      mockStarknetMessagingAddress,
+      INCENTIVES_CONTROLLER,
+      [aDai.address],
+      [l2StaticADai.address],
+    ]);
+    await l1BridgeProxy["initialize(address,address,bytes)"](
+      l1BridgeImpl.address,
+      l1ProxyAdmin.address,
+      encodedInitializedParams
+    );
+    l1Bridge = await ethers.getContractAt(
+      "Bridge",
+      l1BridgeProxy.address,
+      signer
+    );
+  });
+
+  it("initialize the bridge on L1 and L2", async () => {
+    // set L1 token bridge from L2 bridge
+    await l2user.invoke(l2Bridge, "initialize_bridge", {
+      governor_address: BigInt(l2user.starknetContract.address),
+    });
+    await l2user.invoke(l2Bridge, "set_l1_bridge", {
+      l1_bridge_address: BigInt(l1Bridge.address),
+    });
+
+    // map L1 tokens to L2 tokens on L2 bridge
+    await l2user.invoke(l2Bridge, "set_reward_token", {
+      reward_token: BigInt(l2rewAAVE.address),
+    });
+    await l2user.invoke(l2Bridge, "approve_bridge", {
+      l1_token: BigInt(aDai.address),
+      l2_token: BigInt(l2StaticADai.address),
+    });
+  });
+
+  it("cancel aDai deposit", async () => {
+    await aDai.connect(l1user).approve(l1Bridge.address, MAX_UINT256);
+    const l1userBalanceBeforeDeposit = await aDai.balanceOf(l1user.address);
+    txDai = await l1Bridge
+      .connect(l1user)
+      .deposit(
+        aDai.address,
+        BigInt(l2user.starknetContract.address),
+        10n * DAI_UNIT,
+        0,
+        false
+      );
+    const receipt = await txDai.wait();
+
+    const depositEvent = receipt.events
+      .filter((x: any) => (x.event = "Deposit"))
+      .at(-1);
+
+    let deposit_amount = depositEvent.args[2];
+    let current_rewards_index = depositEvent.args[5];
+    let blockNumber = depositEvent.args[4];
+    let nonce = 0;
+
+    await l1Bridge
+      .connect(l1user)
+      .startDepositCancellation(
+        aDai.address,
+        deposit_amount,
+        BigInt(l2user.starknetContract.address),
+        current_rewards_index,
+        blockNumber,
+        nonce
+      );
+
+    await l1Bridge
+      .connect(l1user)
+      .cancelDeposit(
+        aDai.address,
+        deposit_amount,
+        BigInt(l2user.starknetContract.address),
+        current_rewards_index,
+        blockNumber,
+        nonce
+      );
+    const l1userBalanceAfterCancellation = BigNumber.from(
+      await aDai.balanceOf(l1user.address)
+    );
+
+    //check that aTokens were safely transferred back to the user
+    expect(l1userBalanceAfterCancellation).to.be.gte(
+      l1userBalanceBeforeDeposit
+    );
+  });
+});


### PR DESCRIPTION
 Addressed in this PR:
- Current implementation on`Bridge.sol` allows the consuming of the `bridge rewards messages` from l2 before checking if there are enough rewards on the bridge, to **avoid a revert** on `_transferRewards ` when not enough rewards are found. To fix that, a `getAvailableRewards` function was suggested to check for the total amount of rewards available on the bridge (both `claimed` and `pending `) before consuming of the l2 message and transfer of tokens logic. 
- Added L1->L2 message cancellation on `Bridge.sol` for aTokens deposit on L2
- Used onlyValidL2Address modifier on `initialize` to check if l2Bridge is a valid Cairo address instead of the require function. 